### PR TITLE
Allow drum pattern generator to address notes

### DIFF
--- a/midipal/apps/drum_pattern_generator.cc
+++ b/midipal/apps/drum_pattern_generator.cc
@@ -96,7 +96,7 @@ void DrumPatternGenerator::OnInit() {
   Ui::AddClockPages();
   Ui::AddPage(STR_RES_CHN, UNIT_INDEX, 0, 15);
   for (uint8_t i = 0; i < kNumDrumParts; ++i) {
-    Ui::AddPage(STR_RES_PT1 + i, UNIT_NOTE, 20, 108);
+    Ui::AddPage(STR_RES_PT1 + i, UNIT_NOTE, 0, 108);
   }
   Clock::Update(bpm(), groove_template(), groove_amount());
   Clock::Start();


### PR DESCRIPTION
down to C-1 (note number 0) so that it can
trigger different drums on Analog Rytm (notes 0-11)